### PR TITLE
Fix for #53 - add support for user_data to function droplet_new

### DIFF
--- a/R/droplet-actions.R
+++ b/R/droplet-actions.R
@@ -20,6 +20,8 @@
 #' be enabled for the Droplet. Automated backups can only be enabled when the Droplet is created.
 #' Default: FALSE
 #' @param ipv6 (logical) A boolean indicating whether IPv6 is enabled on the Droplet.
+#' @param user_data (character) Gets passed to the Droplet at boot time. Not all regions have this enabled, 
+#' and is not used by all images.
 #' @param ... Additional options passed down to \code{\link[httr]{POST}}
 #' @examples \dontrun{
 #' droplet_new()

--- a/man/droplet_new.Rd
+++ b/man/droplet_new.Rd
@@ -7,7 +7,8 @@ droplet_new(name = random_name(), size = getOption("do_size", "512mb"),
   image = getOption("do_image", "ubuntu-14-04-x64"),
   region = getOption("do_region", "sfo1"), ssh_keys = NULL,
   backups = getOption("do_backups", NULL), ipv6 = getOption("do_ipv6",
-  NULL), private_networking = getOption("do_private_networking", NULL), ...)
+  NULL), private_networking = getOption("do_private_networking", NULL),
+  user_data = NULL, ...)
 }
 \arguments{
 \item{name}{(character) Name of the droplet. Default: picks a random name if none supplied.}
@@ -32,6 +33,9 @@ Default: FALSE}
 
 \item{private_networking}{(logical) Use private networking. Private networking is currently
 only available in certain regions. Default: FALSE}
+
+\item{user_data}{(character) Gets passed to the Droplet at boot time. Not all regions have this enabled,
+and is not used by all images.}
 
 \item{...}{Additional options passed down to \code{\link[httr]{POST}}}
 }


### PR DESCRIPTION
Fixes #53

I did not check, if the region supports  "user_data" . This could be done by checking against the "metadata" feature of the region.

If not supported, the api call still works, as far as I remember. 

If an image really uses the user_data passed in cannot be verified automatically. But the call never fails, if not.
