### PR TITLE
use updated location for rstudio docker image

### DIFF
--- a/R/docklet.R
+++ b/R/docklet.R
@@ -105,7 +105,7 @@ docklet_docker <- function(droplet, cmd, args = NULL, docker_args = NULL, ssh_us
 docklet_rstudio <- function(droplet, 
                             user = 'rstudio', password = 'rstudio', 
                             email = 'rstudio@example.com', 
-                            img = 'eddelbuettel/ubuntu-rstudio', 
+                            img = 'rocker/rstudio', 
                             port = '8787',
                             browse = TRUE, verbose = TRUE,
                             ssh_user = "root") {


### PR DESCRIPTION
We've moved the R Docker images to a Docker organization ([rocker](https://registry.hub.docker.com/repos/rocker/), corresponding github repo now it's own github org as well: [rocker-org](https://github.com/rocker-org/rocker)) and shortened the image names. Though the original images won't disappear from the Hub immediately, figured I might as well update the paths. 
