### PR TITLE
#217 Add page and per_page parameters to snapshots function

### DIFF
--- a/R/snapshots.R
+++ b/R/snapshots.R
@@ -32,6 +32,8 @@ as.snapshot.character <- function(x) {
 #'   \code{\link{as.snapshot}}.
 #' @param type (character) \code{NULL} (all snapshots), or one of droplet
 #' (droplet snapshots) or volume (volume snapshots)
+#' @param page Which 'page' of paginated results to return (default 1).
+#' @param per_page Number of items returned per page (default 20, maximum 200)
 #' @param id A snapshot id (varies depending on droplet or volume ID)
 #' @param ... Additional options passed down to \code{\link[httr]{GET}},
 #' \code{\link[httr]{POST}}, etc.
@@ -44,6 +46,10 @@ as.snapshot.character <- function(x) {
 #'
 #' # list volume snapshots
 #' snapshots(type = "volume")
+#'
+#' # paging
+#' snapshots(per_page = 5)
+#' snapshots(per_page = 5, page = 2)
 #'
 #' # get a single snapshot
 #' snapshot(res[[1]]$id)
@@ -62,9 +68,12 @@ as.snapshot.character <- function(x) {
 
 #' @export
 #' @rdname snapshots
-snapshots <- function(type = NULL, ...) {
+snapshots <- function(type = NULL, page = 1, per_page = 20, ...) {
+  per_page = max(per_page, 200)
   as.snapshot(
-    do_GET(snapshot_url(), query = ascompact(list(resource_type = type)), ...)
+    do_GET(snapshot_url(), query = ascompact(list(resource_type = type,
+                                                  page = page, 
+                                                  per_page = per_page)), ...)
   )
 }
 

--- a/R/snapshots.R
+++ b/R/snapshots.R
@@ -69,7 +69,7 @@ as.snapshot.character <- function(x) {
 #' @export
 #' @rdname snapshots
 snapshots <- function(type = NULL, page = 1, per_page = 20, ...) {
-  per_page = max(per_page, 200)
+  per_page = min(per_page, 200)
   as.snapshot(
     do_GET(snapshot_url(), query = ascompact(list(resource_type = type,
                                                   page = page, 

--- a/man/snapshots.Rd
+++ b/man/snapshots.Rd
@@ -9,7 +9,7 @@
 \usage{
 as.snapshot(x)
 
-snapshots(type = NULL, ...)
+snapshots(type = NULL, page = 1, per_page = 20, ...)
 
 snapshot(id, ...)
 
@@ -20,6 +20,10 @@ snapshot_delete(snapshot, ...)
 
 \item{type}{(character) \code{NULL} (all snapshots), or one of droplet
 (droplet snapshots) or volume (volume snapshots)}
+
+\item{page}{Which 'page' of paginated results to return (default 1).}
+
+\item{per_page}{Number of items returned per page (default 20, maximum 200)}
 
 \item{...}{Additional options passed down to \code{\link[httr]{GET}},
 \code{\link[httr]{POST}}, etc.}
@@ -46,6 +50,10 @@ snapshots(type = "droplet")
 
 # list volume snapshots
 snapshots(type = "volume")
+
+# paging
+snapshots(per_page = 5)
+snapshots(per_page = 5, page = 2)
 
 # get a single snapshot
 snapshot(res[[1]]$id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current implementation of snapshots function does not support `page` and `per_page` parameters, which facilitate the pagination of the results, as well as setting the number of items to be returned per page. Consequently, the DO response always uses the default values of `page = 1` and `per_page = 20`. In cases when there are more than 20 snapshots in the account, it is not possible to retrieve snapshots other than the first 20.

This PR adds `page` and `per_page` parameters to the `snapshots` function. The default values are the same as specified by Digital Ocean API `snapshots` endpoint, `page=1` and `per_page=20`.

Allowed range of `per_page` parameter is from `1` to `200`, so the proposed change resets the passed value if it was greater than 200.

## Related Issue
Fixes issue #217.

## Example

Example usage:

```
snapshots(per_page = 5, page = 2)
```
